### PR TITLE
Fixing pogreb + bbolt logic

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       - name: Check out code
         uses: actions/checkout@v2
@@ -23,3 +23,4 @@ jobs:
 
       - name: Build
         run: go build .
+        working-directory: cmd/example/

--- a/cmd/example/example.go
+++ b/cmd/example/example.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/projectdiscovery/hmap/store/hybrid"
 )
 
@@ -132,7 +133,7 @@ func hybridz(wg *sync.WaitGroup) {
 func allDisks(wg *sync.WaitGroup) error {
 	defer wg.Done()
 
-	total := 10000000
+	total := 25000
 
 	opts := hybrid.DefaultDiskOptions
 	// leveldb
@@ -151,6 +152,7 @@ func allDisks(wg *sync.WaitGroup) error {
 
 	// bbolt
 	opts.DBType = hybrid.BBoltDB
+	opts.Name = "test"
 	_, err = testhybrid("bbolt", opts, total)
 	if err != nil {
 		return err
@@ -182,7 +184,10 @@ func testhybrid(name string, opts hybrid.Options, total int) (duration time.Dura
 	// scan
 	read := 0
 	hm.Scan(func(k, v []byte) error {
-		_, _ = k, v
+		gotValue := string(v)
+		if "test" != gotValue {
+			return errors.New("unexpected item")
+		}
 		read++
 		return nil
 	})

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/onsi/gomega v1.16.0 // indirect
+	github.com/pkg/errors v0.9.1
 	github.com/projectdiscovery/filekv v0.0.0-20210915124239-3467ef45dd08
 	github.com/projectdiscovery/fileutil v0.0.0-20220308101036-16c79af1cf5d
 	github.com/projectdiscovery/stringsutil v0.0.0-20220208075244-7c05502ca8e9

--- a/store/disk/bboltdb.go
+++ b/store/disk/bboltdb.go
@@ -2,10 +2,11 @@ package disk
 
 import (
 	"bytes"
-	"errors"
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/pkg/errors"
 
 	bolt "go.etcd.io/bbolt"
 )
@@ -94,9 +95,8 @@ func (b *BBoltDB) get(k string) ([]byte, error) {
 		expires, actual := parts[0], parts[1]
 		if exp, _ := strconv.Atoi(string(expires)); exp > 0 && int(time.Now().Unix()) >= exp {
 			delete = true
-		} else {
-			data = actual
 		}
+		data = actual
 
 		if delete {
 			return b.Delete([]byte(k))
@@ -182,7 +182,12 @@ func (b *BBoltDB) Scan(scannerOpt ScannerOptions) error {
 		}
 		c := b.Cursor()
 		for key, val := c.First(); key != nil; key, val = c.Next() {
-			if !valid(key) || scannerOpt.Handler(key, val) != nil {
+			parts := bytes.SplitN(val, []byte(expSeparator), 2)
+			data := val
+			if len(parts) == 2 {
+				data = parts[1]
+			}
+			if !valid(key) || scannerOpt.Handler(key, data) != nil {
 				break
 			}
 		}

--- a/store/disk/error.go
+++ b/store/disk/error.go
@@ -1,6 +1,6 @@
 package disk
 
-import "errors"
+import "github.com/pkg/errors"
 
 var (
 	ErrNotImplemented = errors.New("not implemented")

--- a/store/hybrid/hybrid.go
+++ b/store/hybrid/hybrid.go
@@ -43,6 +43,7 @@ type Options struct {
 	MemoryGuardTime      time.Duration
 	Path                 string
 	Cleanup              bool
+	Name                 string
 	// Remove temporary hmap in the temporary folder older than duration
 	RemoveOlderThan time.Duration
 }
@@ -141,6 +142,7 @@ func New(options Options) (*HybridMap, error) {
 			if err != nil {
 				return nil, err
 			}
+			db.BucketName = options.Name
 			hm.diskmap = db
 		case FileDB:
 			db, err := disk.OpenFileDB(filepath.Join(diskmapPathm, "ff"))


### PR DESCRIPTION
## Description
This PR removes the value TTL prefixed to the byte value stream within the key-value store. This behavior prevented bbolt and pogreb from performing `get` and `scan` operations

## How to reproduce
```console
$ go run .
2022/04/19 19:12:38 [98]
2022/04/19 19:12:38 b
2022/04/19 19:12:53 item evicted
2022/04/19 19:12:53 Read1 (disk) [98]
2022/04/19 19:12:53 Writing 1M
2022/04/19 19:12:56 Finished writing 1M
2022/04/19 19:13:11 Read2 (memory) [98]
2022/04/19 19:13:11 starting: leveldb
2022/04/19 19:13:11 written: 25000,read 25000, took:101.5464ms
2022/04/19 19:13:11 starting: pogreb
2022/04/19 19:13:12 written: 25000,read 25000, took:702.4614ms
2022/04/19 19:13:12 starting: bbolt
2022/04/19 19:14:03 written: 25000,read 25000, took:51.3521272s
```