### PR TITLE
Increasing leveldb table size to 32Mb

### DIFF
--- a/store/disk/disk.go
+++ b/store/disk/disk.go
@@ -1,3 +1,5 @@
 package disk
 
+const Megabyte = 1 << 20
+
 var OpenPogrebDB func(string) (DB, error)

--- a/store/disk/leveldb.go
+++ b/store/disk/leveldb.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/iterator"
+	"github.com/syndtr/goleveldb/leveldb/opt"
 	"github.com/syndtr/goleveldb/leveldb/util"
 )
 
@@ -21,7 +22,9 @@ type LevelDB struct {
 
 // OpenLevelDB - Opens the specified path
 func OpenLevelDB(path string) (*LevelDB, error) {
-	db, err := leveldb.OpenFile(path, nil)
+	db, err := leveldb.OpenFile(path, &opt.Options{
+		CompactionTableSize: 32 * Megabyte,
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description
This PR increases the leveldb table file size to 32Mb, reducing the number of files created since previously blocks of 2Mb were used. The size can be further increased if still too many files are created.